### PR TITLE
fix the length variable

### DIFF
--- a/pytnt/utils.py
+++ b/pytnt/utils.py
@@ -70,7 +70,7 @@ def convert_si(si_num_list):
 
 def read_pascal_string(data, number_type='<i4', encoding='ascii'):
     number_type = np.dtype(number_type)
-    length = np.fromstring(data, dtype=number_type, count=1)
+    length = np.fromstring(data, dtype=number_type, count=1)[0]
     number_size = number_type.itemsize
     text = data[number_size:number_size + length]
     if not isinstance(text, str):


### PR DESCRIPTION
On line 73, change:
length = np.fromstring(data, dtype=number_type, count=1)
to:
length = np.fromstring(data, dtype=number_type, count=1)[0]

currently, length isn't a integer, but a list containing an integer. This pull request would fix that.