### PR TITLE
Skip bogus delay tables

### DIFF
--- a/pytnt/processTNT.py
+++ b/pytnt/processTNT.py
@@ -59,7 +59,11 @@ class TNTfile:
                 offset = (match.start() - 4)
                 # extract the name length, the name, the delay length,
                 # and the delay.
-                delay_name = read_pascal_string(search_region[offset:])
+                try:
+                    delay_name = read_pascal_string(search_region[offset:])
+                except IndexError:
+                    # Not a real delay table - the Pascal string was invalid
+                    continue
                 offset = match.start() + len(delay_name)
                 delay = read_pascal_string(search_region[offset:])
                 # Now check for delay tables of length one and discard them

--- a/pytnt/utils.py
+++ b/pytnt/utils.py
@@ -72,6 +72,10 @@ def read_pascal_string(data, number_type='<i4', encoding='ascii'):
     number_type = np.dtype(number_type)
     length = np.frombuffer(data, dtype=number_type, count=1).item()
     number_size = number_type.itemsize
+    if len(data) < number_size + length:
+        raise IndexError("Pascal string claims to have length %d but only "
+                         "%d bytes of data are available" % (
+                                 length, len(data) - number_size))
     text = data[number_size:number_size + length]
     if not isinstance(text, str):
         text = str(text, encoding)


### PR DESCRIPTION
Ignore cases where the delay table regex finds something which is not a valid delay table.